### PR TITLE
Change output ecmascript to 2018 to support Node 12

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "ES2020",
+    "target": "ES2018",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "declaration": true,


### PR DESCRIPTION
This package is used by `vscode-js-debug`, and compiled to `ES2020` which isn't supported by Node v12 - this PR changes that. 